### PR TITLE
refactor: change domain model for keywords

### DIFF
--- a/src/main/kotlin/no/fdk/dataservicecatalog/domain/DataService.kt
+++ b/src/main/kotlin/no/fdk/dataservicecatalog/domain/DataService.kt
@@ -47,7 +47,7 @@ data class DataService(
     /*
     emneord (dcat:keyword)
      */
-    val keywords: List<LocalizedStrings>? = null,
+    val keywords: LocalizedStringLists? = null,
 
     /*
     endepunktsbeskrivelse (dcat:endpointDescription)
@@ -119,7 +119,7 @@ data class RegisterDataService(
 
     val title: LocalizedStrings,
 
-    val keywords: List<LocalizedStrings>? = null,
+    val keywords: LocalizedStringLists? = null,
 
     val endpointDescriptions: List<String>? = null,
 
@@ -150,6 +150,12 @@ data class LocalizedStrings(
     val nb: String? = null,
     val nn: String? = null,
     val en: String? = null,
+)
+
+data class LocalizedStringLists(
+    val nb: List<String>? = null,
+    val nn: List<String>? = null,
+    val en: List<String>? = null,
 )
 
 data class ContactPoint(

--- a/src/main/kotlin/no/fdk/dataservicecatalog/handler/RDFHandler.kt
+++ b/src/main/kotlin/no/fdk/dataservicecatalog/handler/RDFHandler.kt
@@ -155,13 +155,13 @@ fun Model.addDataService(dataService: DataService, dataServiceUri: String) {
         }
     }
 
-    dataService.keywords?.forEach { keyword ->
+    dataService.keywords?.let { keyword ->
         listOf(
             "nb" to keyword.nb,
             "nn" to keyword.nn,
             "en" to keyword.en,
         ).forEach { (lang, value) ->
-            value?.let {
+            value?.forEach {
                 dataServiceResource.addProperty(
                     DCAT.keyword, ResourceFactory.createLangLiteral(it, lang)
                 )

--- a/src/test/kotlin/no/fdk/dataservicecatalog/unit/handler/RDFHandlerTest.kt
+++ b/src/test/kotlin/no/fdk/dataservicecatalog/unit/handler/RDFHandlerTest.kt
@@ -324,7 +324,7 @@ class RDFHandlerTest {
         status = Status.PUBLISHED,
         endpointUrl = "http://example.com",
         title = LocalizedStrings(en = "title"),
-        keywords = listOf(LocalizedStrings(en = "keyword")),
+        keywords = LocalizedStringLists(en = listOf("keyword")),
         endpointDescriptions = listOf("http://endpoint-description.com"),
         formats = listOf("http://format.com"),
         contactPoint = ContactPoint(


### PR DESCRIPTION
refaktorerer keywords for å kunne behandle det på samme måte som tillattTerm i begrepskatalogen, ref: https://github.com/Informasjonsforvaltning/catalog-frontend/issues/944#issuecomment-2602734655