### PR TITLE
refactor: simplify license in domain model

### DIFF
--- a/src/main/kotlin/no/fdk/dataservicecatalog/domain/DataService.kt
+++ b/src/main/kotlin/no/fdk/dataservicecatalog/domain/DataService.kt
@@ -92,7 +92,7 @@ data class DataService(
     /*
     lisens (dct:license)
      */
-    val license: License? = null,
+    val license: String? = null,
 
     /*
     medietype (dcat:mediaType)
@@ -137,7 +137,7 @@ data class RegisterDataService(
 
     val landingPage: String? = null,
 
-    val license: License? = null,
+    val license: String? = null,
 
     val mediaTypes: List<String>? = null,
 
@@ -162,11 +162,6 @@ data class ContactPoint(
     val organizationUnit: String? = null,
     val phone: String? = null,
     val email: String? = null,
-    val url: String? = null
-)
-
-data class License(
-    val name: String? = null,
     val url: String? = null
 )
 

--- a/src/main/kotlin/no/fdk/dataservicecatalog/handler/RDFHandler.kt
+++ b/src/main/kotlin/no/fdk/dataservicecatalog/handler/RDFHandler.kt
@@ -261,7 +261,7 @@ fun Model.addDataService(dataService: DataService, dataServiceUri: String) {
         )
     }
 
-    dataService.license?.url?.takeIf(FileUtils::isURI)?.let {
+    dataService.license?.takeIf(FileUtils::isURI)?.let {
         dataServiceResource.addProperty(
             DCTerms.license, ResourceFactory.createResource(URIref.encode(it))
         )

--- a/src/test/kotlin/no/fdk/dataservicecatalog/unit/handler/RDFHandlerTest.kt
+++ b/src/test/kotlin/no/fdk/dataservicecatalog/unit/handler/RDFHandlerTest.kt
@@ -337,10 +337,7 @@ class RDFHandlerTest {
         description = LocalizedStrings(en = "description"),
         pages = listOf("http://page.com"),
         landingPage = "http://landing-page.com",
-        license = License(
-            name = "name",
-            url = "http://license.com"
-        ),
+        license = "http://license.com",
         mediaTypes = listOf("https://www.iana.org/assignments/media-types/application/json"),
         accessRights = "http://access-rights.com",
         type = "http://type.com"


### PR DESCRIPTION
har kun behov for å lagre url fra kodeliste, `name` kommer ikke til å bli brukt