### PR TITLE
refactor: change type of status to String & add published bool field

### DIFF
--- a/src/main/kotlin/no/fdk/dataservicecatalog/config/MongoConfig.kt
+++ b/src/main/kotlin/no/fdk/dataservicecatalog/config/MongoConfig.kt
@@ -25,9 +25,9 @@ class MongoConfig : AuditorAware<User> {
     fun configureIndexes(mongoOperations: MongoOperations): Boolean {
         val indexOps = mongoOperations.indexOps(DataService::class.java)
 
-        indexOps.ensureIndex(Index().on("catalogId", Sort.Direction.ASC).on("status", Sort.Direction.ASC))
+        indexOps.ensureIndex(Index().on("catalogId", Sort.Direction.ASC).on("published", Sort.Direction.ASC))
 
-        indexOps.ensureIndex(CompoundIndexDefinition(Document().append("catalogId", 1).append("status", 1)))
+        indexOps.ensureIndex(CompoundIndexDefinition(Document().append("catalogId", 1).append("published", 1)))
 
         return true
     }

--- a/src/main/kotlin/no/fdk/dataservicecatalog/domain/DataService.kt
+++ b/src/main/kotlin/no/fdk/dataservicecatalog/domain/DataService.kt
@@ -18,6 +18,8 @@ data class DataService(
     @Id
     val id: String,
 
+    val published: Boolean = false,
+
     @CreatedDate
     val created: LocalDateTime? = null,
 
@@ -32,7 +34,7 @@ data class DataService(
 
     val catalogId: String,
 
-    val status: Status,
+    val status: String?,
 
     /*
     endepunktsURL (dcat:endpointURL)
@@ -112,7 +114,7 @@ data class DataService(
 
 data class RegisterDataService(
 
-    val status: Status? = null,
+    val status: String? = null,
 
     @field:NotBlank(message = "Cannot be blank")
     val endpointUrl: String,
@@ -164,7 +166,3 @@ data class ContactPoint(
     val email: String? = null,
     val url: String? = null
 )
-
-enum class Status {
-    DRAFT, PUBLISHED
-}

--- a/src/main/kotlin/no/fdk/dataservicecatalog/handler/DataServiceHandler.kt
+++ b/src/main/kotlin/no/fdk/dataservicecatalog/handler/DataServiceHandler.kt
@@ -3,7 +3,6 @@ package no.fdk.dataservicecatalog.handler
 import no.fdk.dataservicecatalog.domain.DataService
 import no.fdk.dataservicecatalog.domain.PatchRequest
 import no.fdk.dataservicecatalog.domain.RegisterDataService
-import no.fdk.dataservicecatalog.domain.Status
 import no.fdk.dataservicecatalog.exception.NotFoundException
 import no.fdk.dataservicecatalog.repository.DataServiceRepository
 import org.slf4j.Logger
@@ -31,7 +30,7 @@ class DataServiceHandler(private val repository: DataServiceRepository) {
             DataService(
                 id = id,
                 catalogId = catalogId,
-                status = registerDataService.status ?: Status.DRAFT,
+                status = registerDataService.status,
                 endpointUrl = registerDataService.endpointUrl,
                 title = registerDataService.title,
                 keywords = registerDataService.keywords,

--- a/src/main/kotlin/no/fdk/dataservicecatalog/handler/RDFHandler.kt
+++ b/src/main/kotlin/no/fdk/dataservicecatalog/handler/RDFHandler.kt
@@ -79,7 +79,8 @@ class RDFHandler(private val repository: DataServiceRepository, private val prop
                         "dct" to DCTerms.NS,
                         "rdf" to RDF.uri,
                         "vcard" to VCARD4.NS,
-                        "foaf" to FOAF.NS
+                        "foaf" to FOAF.NS,
+                        "adms" to ADMS.NS
                     )
                 )
             }

--- a/src/main/kotlin/no/fdk/dataservicecatalog/rdf/ADMS.kt
+++ b/src/main/kotlin/no/fdk/dataservicecatalog/rdf/ADMS.kt
@@ -1,0 +1,12 @@
+package no.fdk.dataservicecatalog.rdf
+
+import org.apache.jena.rdf.model.Property
+import org.apache.jena.rdf.model.ResourceFactory
+
+class ADMS {
+    companion object {
+        const val uri = "http://www.w3.org/ns/adms#"
+
+        val status: Property = ResourceFactory.createProperty("${uri}status")
+    }
+}

--- a/src/main/kotlin/no/fdk/dataservicecatalog/rdf/ADMS.kt
+++ b/src/main/kotlin/no/fdk/dataservicecatalog/rdf/ADMS.kt
@@ -5,8 +5,8 @@ import org.apache.jena.rdf.model.ResourceFactory
 
 class ADMS {
     companion object {
-        const val uri = "http://www.w3.org/ns/adms#"
+        const val NS = "http://www.w3.org/ns/adms#"
 
-        val status: Property = ResourceFactory.createProperty("${uri}status")
+        val status: Property = ResourceFactory.createProperty("${NS}status")
     }
 }

--- a/src/main/kotlin/no/fdk/dataservicecatalog/repository/DataServiceRepository.kt
+++ b/src/main/kotlin/no/fdk/dataservicecatalog/repository/DataServiceRepository.kt
@@ -1,7 +1,6 @@
 package no.fdk.dataservicecatalog.repository
 
 import no.fdk.dataservicecatalog.domain.DataService
-import no.fdk.dataservicecatalog.domain.Status
 import org.springframework.data.mongodb.repository.MongoRepository
 import org.springframework.stereotype.Repository
 
@@ -14,7 +13,7 @@ interface DataServiceRepository : MongoRepository<DataService, String> {
 
     fun findDataServiceById(dataServiceId: String): DataService?
 
-    fun findAllByStatus(status: Status): List<DataService>
+    fun findAllByPublished(published: Boolean): List<DataService>
 
-    fun findAllByCatalogIdAndStatus(catalogId: String, status: Status): List<DataService>
+    fun findAllByCatalogIdAndPublished(catalogId: String, published: Boolean): List<DataService>
 }

--- a/src/test/kotlin/no/fdk/dataservicecatalog/integration/config/MongoConfigTest.kt
+++ b/src/test/kotlin/no/fdk/dataservicecatalog/integration/config/MongoConfigTest.kt
@@ -24,8 +24,8 @@ class MongoConfigTest(@Autowired val operations: MongoOperations) {
         val indexOps = operations.indexOps(DataService::class.java)
 
         assertTrue(hasIndex(indexOps, listOf("catalogId")))
-        assertTrue(hasIndex(indexOps, listOf("status")))
-        assertTrue(hasIndex(indexOps, listOf("catalogId", "status")))
+        assertTrue(hasIndex(indexOps, listOf("published")))
+        assertTrue(hasIndex(indexOps, listOf("catalogId", "published")))
     }
 
     private fun hasIndex(indexOps: IndexOperations, name: List<String>) =

--- a/src/test/kotlin/no/fdk/dataservicecatalog/integration/controller/DataServiceControllerTest.kt
+++ b/src/test/kotlin/no/fdk/dataservicecatalog/integration/controller/DataServiceControllerTest.kt
@@ -71,7 +71,8 @@ class DataServiceControllerTest(@Autowired val mockMvc: MockMvc) {
             on { findById(catalogId, dataServiceId) } doReturn DataService(
                 id = dataServiceId,
                 catalogId = catalogId,
-                status = Status.PUBLISHED,
+                published = true,
+                status = null,
                 endpointUrl = "endpointUrl",
                 title = LocalizedStrings(nb = "title")
             )
@@ -260,7 +261,8 @@ class DataServiceControllerTest(@Autowired val mockMvc: MockMvc) {
         val dataService = DataService(
             id = dataServiceId,
             catalogId = catalogId,
-            status = Status.PUBLISHED,
+            published = true,
+            status = null,
             endpointUrl = "endpointUrl",
             title = LocalizedStrings(nb = "title")
         )

--- a/src/test/kotlin/no/fdk/dataservicecatalog/integration/repository/DataServiceRepositoryTest.kt
+++ b/src/test/kotlin/no/fdk/dataservicecatalog/integration/repository/DataServiceRepositoryTest.kt
@@ -2,7 +2,6 @@ package no.fdk.dataservicecatalog.integration.repository
 
 import no.fdk.dataservicecatalog.domain.DataService
 import no.fdk.dataservicecatalog.domain.LocalizedStrings
-import no.fdk.dataservicecatalog.domain.Status
 import no.fdk.dataservicecatalog.integration.MongoDBTestcontainer
 import no.fdk.dataservicecatalog.repository.DataServiceRepository
 import org.junit.jupiter.api.AfterEach
@@ -39,7 +38,8 @@ class DataServiceRepositoryTest(
         val dataService = DataService(
             id = "1111",
             catalogId = firstCatalogId,
-            status = Status.PUBLISHED,
+            published = true,
+            status = null,
             endpointUrl = "endpointUrl",
             title = LocalizedStrings(nb = "title")
         )
@@ -62,7 +62,8 @@ class DataServiceRepositoryTest(
         val dataService = DataService(
             id = "1111",
             catalogId = firstCatalogId,
-            status = Status.PUBLISHED,
+            published = true,
+            status = null,
             endpointUrl = "endpointUrl",
             title = LocalizedStrings(nb = "title")
         )
@@ -86,7 +87,8 @@ class DataServiceRepositoryTest(
             DataService(
                 id = dataServiceId,
                 catalogId = catalogId,
-                status = Status.PUBLISHED,
+                published = true,
+                status = null,
                 endpointUrl = "endpointUrl",
                 title = LocalizedStrings(nb = "title")
             )
@@ -98,48 +100,48 @@ class DataServiceRepositoryTest(
     }
 
     @Test
-    fun `find all by status`() {
+    fun `find all by published status`() {
         val catalogId = "1234"
-        val status = Status.PUBLISHED
 
         val dataService = DataService(
             id = "1111",
             catalogId = catalogId,
-            status = status,
+            published = true,
+            status = null,
             endpointUrl = "endpointUrl",
             title = LocalizedStrings(nb = "title")
         )
 
         operations.insertAll(
-            listOf(dataService, dataService.copy(id = "2222", status = Status.DRAFT))
+            listOf(dataService, dataService.copy(id = "2222", published = false))
         )
 
-        val dataServices = repository.findAllByStatus(status)
+        val dataServices = repository.findAllByPublished(true)
 
         assertEquals(1, dataServices.count())
-        assertEquals(Status.PUBLISHED, dataServices.first().status)
+        assertEquals(true, dataServices.first().published)
     }
 
     @Test
-    fun `find all by catalog id and status`() {
+    fun `find all by catalog id and published status`() {
         val catalogId = "1234"
-        val status = Status.PUBLISHED
 
         val dataService = DataService(
             id = "1111",
             catalogId = catalogId,
-            status = status,
+            published = true,
+            status = null,
             endpointUrl = "endpointUrl",
             title = LocalizedStrings(nb = "title")
         )
 
         operations.insertAll(
-            listOf(dataService, dataService.copy(id = "2222", status = Status.DRAFT))
+            listOf(dataService, dataService.copy(id = "2222", published = false))
         )
 
-        val dataServices = repository.findAllByCatalogIdAndStatus(catalogId, status)
+        val dataServices = repository.findAllByCatalogIdAndPublished(catalogId, true)
 
         assertEquals(1, dataServices.count())
-        assertEquals(Status.PUBLISHED, dataServices.first().status)
+        assertEquals(true, dataServices.first().published)
     }
 }

--- a/src/test/kotlin/no/fdk/dataservicecatalog/unit/handler/CountHandlerTest.kt
+++ b/src/test/kotlin/no/fdk/dataservicecatalog/unit/handler/CountHandlerTest.kt
@@ -2,7 +2,6 @@ package no.fdk.dataservicecatalog.unit.handler
 
 import no.fdk.dataservicecatalog.domain.DataService
 import no.fdk.dataservicecatalog.domain.LocalizedStrings
-import no.fdk.dataservicecatalog.domain.Status
 import no.fdk.dataservicecatalog.handler.CountHandler
 import no.fdk.dataservicecatalog.repository.DataServiceRepository
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -31,7 +30,8 @@ class CountHandlerTest {
         val dataService = DataService(
             id = "1111",
             catalogId = firstCatalogId,
-            status = Status.PUBLISHED,
+            published = true,
+            status = null,
             endpointUrl = "endpointUrl",
             title = LocalizedStrings(nb = "title")
         )
@@ -66,7 +66,8 @@ class CountHandlerTest {
         val dataService = DataService(
             id = "1111",
             catalogId = firstCatalogId,
-            status = Status.PUBLISHED,
+            published = true,
+            status = null,
             endpointUrl = "endpointUrl",
             title = LocalizedStrings(nb = "title")
         )

--- a/src/test/kotlin/no/fdk/dataservicecatalog/unit/handler/DataServiceHandlerTest.kt
+++ b/src/test/kotlin/no/fdk/dataservicecatalog/unit/handler/DataServiceHandlerTest.kt
@@ -33,7 +33,8 @@ class DataServiceHandlerTest {
                 DataService(
                     id = "5678",
                     catalogId = catalogId,
-                    status = Status.PUBLISHED,
+                    published = true,
+                    status = null,
                     endpointUrl = "endpointUrl",
                     title = LocalizedStrings(nb = "title")
                 )
@@ -54,7 +55,8 @@ class DataServiceHandlerTest {
             on { findDataServiceById(dataServiceId) } doReturn DataService(
                 id = dataServiceId,
                 catalogId = catalogId,
-                status = Status.PUBLISHED,
+                published = true,
+                status = null,
                 endpointUrl = "endpointUrl",
                 title = LocalizedStrings(nb = "title")
             )
@@ -74,7 +76,8 @@ class DataServiceHandlerTest {
             on { findDataServiceById(dataServiceId) } doReturn DataService(
                 id = dataServiceId,
                 catalogId = "invalid_catalog id",
-                status = Status.PUBLISHED,
+                published = true,
+                status = null,
                 endpointUrl = "endpointUrl",
                 title = LocalizedStrings(nb = "title")
             )
@@ -109,7 +112,8 @@ class DataServiceHandlerTest {
         val dataService = DataService(
             id = dataServiceId,
             catalogId = catalogId,
-            status = Status.PUBLISHED,
+            published = true,
+            status = null,
             endpointUrl = "endpointUrl",
             title = LocalizedStrings(nb = "title")
         )
@@ -147,7 +151,8 @@ class DataServiceHandlerTest {
             on { findDataServiceById(dataServiceId) } doReturn DataService(
                 id = dataServiceId,
                 catalogId = "invalid catalog id",
-                status = Status.PUBLISHED,
+                published = true,
+                status = null,
                 endpointUrl = "endpointUrl",
                 title = LocalizedStrings(nb = "title")
             )
@@ -176,7 +181,8 @@ class DataServiceHandlerTest {
             on { findDataServiceById(dataServiceId) } doReturn DataService(
                 id = dataServiceId,
                 catalogId = catalogId,
-                status = Status.PUBLISHED,
+                published = true,
+                status = null,
                 endpointUrl = "endpointUrl",
                 title = LocalizedStrings(nb = "title")
             )
@@ -196,7 +202,8 @@ class DataServiceHandlerTest {
             on { findDataServiceById(dataServiceId) } doReturn DataService(
                 id = dataServiceId,
                 catalogId = "invalid catalog id",
-                status = Status.PUBLISHED,
+                published = true,
+                status = null,
                 endpointUrl = "endpointUrl",
                 title = LocalizedStrings(nb = "title")
             )

--- a/src/test/kotlin/no/fdk/dataservicecatalog/unit/handler/RDFHandlerTest.kt
+++ b/src/test/kotlin/no/fdk/dataservicecatalog/unit/handler/RDFHandlerTest.kt
@@ -44,7 +44,7 @@ class RDFHandlerTest {
         expectedModel.read(StringReader(rdf), null, Lang.TURTLE.name)
 
         repository.stub {
-            on { findAllByStatus(Status.PUBLISHED) } doReturn emptyList()
+            on { findAllByPublished(true) } doReturn emptyList()
         }
 
         val catalogs = handler.findCatalogs(Lang.TURTLE)
@@ -69,6 +69,7 @@ class RDFHandlerTest {
             PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
             PREFIX rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
             PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+            PREFIX adms:  <http://www.w3.org/ns/adms#>
 
             <$organizationCatalogBaseUri/organizations/$catalogId>
                     rdf:type        foaf:Agent;
@@ -84,6 +85,7 @@ class RDFHandlerTest {
                     dct:license               <http://license.com>;
                     dct:title                 "title"@en;
                     dct:type                  <http://type.com>;
+                    adms:status               <http://publications.europa.eu/resource/authority/distribution-status/DEVELOP>;
                     dcat:contactPoint         [ rdf:type                   vcard:Organization;
                                                 vcard:fn                   "Contact information | (5678)";
                                                 vcard:hasEmail             <mailto:email>;
@@ -111,7 +113,7 @@ class RDFHandlerTest {
         expectedModel.read(StringReader(rdf), null, Lang.TURTLE.name)
 
         repository.stub {
-            on { findAllByStatus(Status.PUBLISHED) } doReturn listOf(
+            on { findAllByPublished(true) } doReturn listOf(
                 dataService().copy(
                     id = dataServiceId,
                     catalogId = catalogId
@@ -148,7 +150,7 @@ class RDFHandlerTest {
         expectedModel.read(StringReader(rdf), null, Lang.TURTLE.name)
 
         repository.stub {
-            on { findAllByCatalogIdAndStatus(catalogId, Status.PUBLISHED) } doReturn emptyList()
+            on { findAllByCatalogIdAndPublished(catalogId, true) } doReturn emptyList()
         }
 
         val catalogs = handler.findCatalogById(catalogId, Lang.TURTLE)
@@ -173,6 +175,7 @@ class RDFHandlerTest {
             PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
             PREFIX rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
             PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+            PREFIX adms:  <http://www.w3.org/ns/adms#>
 
             <$organizationCatalogBaseUri/organizations/$catalogId>
                     rdf:type        foaf:Agent;
@@ -188,6 +191,7 @@ class RDFHandlerTest {
                     dct:license               <http://license.com>;
                     dct:title                 "title"@en;
                     dct:type                  <http://type.com>;
+                    adms:status               <http://publications.europa.eu/resource/authority/distribution-status/DEVELOP>;
                     dcat:contactPoint         [ rdf:type                   vcard:Organization;
                                                 vcard:fn                   "Contact information | (5678)";
                                                 vcard:hasEmail             <mailto:email>;
@@ -215,7 +219,7 @@ class RDFHandlerTest {
         expectedModel.read(StringReader(rdf), null, Lang.TURTLE.name)
 
         repository.stub {
-            on { findAllByCatalogIdAndStatus(catalogId, Status.PUBLISHED) } doReturn listOf(
+            on { findAllByCatalogIdAndPublished(catalogId, true) } doReturn listOf(
                 dataService().copy(
                     id = dataServiceId,
                     catalogId = catalogId
@@ -245,7 +249,8 @@ class RDFHandlerTest {
             on { findDataServiceById(dataServiceId) } doReturn DataService(
                 id = dataServiceId,
                 catalogId = "invalid catalog id",
-                status = Status.PUBLISHED,
+                published = true,
+                status = null,
                 endpointUrl = "endpointUrl",
                 title = LocalizedStrings(nb = "title")
             )
@@ -269,6 +274,7 @@ class RDFHandlerTest {
             PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
             PREFIX rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
             PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+            PREFIX adms:  <http://www.w3.org/ns/adms#>
             
             <$baseUri/catalogs/$catalogId/data-services/$dataServiceId>
                     rdf:type                  dcat:DataService;
@@ -278,6 +284,7 @@ class RDFHandlerTest {
                     dct:license               <http://license.com>;
                     dct:title                 "title"@en;
                     dct:type                  <http://type.com>;
+                    adms:status               <http://publications.europa.eu/resource/authority/distribution-status/DEVELOP>;
                     dcat:contactPoint         [ rdf:type                   vcard:Organization;
                                                 vcard:fn                   "Contact information | (5678)";
                                                 vcard:hasEmail             <mailto:email>;
@@ -321,7 +328,8 @@ class RDFHandlerTest {
     private fun dataService() = DataService(
         id = "1234",
         catalogId = "5678",
-        status = Status.PUBLISHED,
+        published = true,
+        status = "http://publications.europa.eu/resource/authority/distribution-status/DEVELOP",
         endpointUrl = "http://example.com",
         title = LocalizedStrings(en = "title"),
         keywords = LocalizedStringLists(en = listOf("keyword")),


### PR DESCRIPTION
endrer status til String for å kunne støtte verdier fra kodelisten som skal brukes: https://data.norge.no/specification/dcat-ap-no#Datatjeneste-status

fjerner også publiseringstilstand fra status, siden det ikke er en del av kodelista, legger det i stedet til et boolean-felt