### PR TITLE
fix: RDFHandler does not fail on null values & uses old base uri

### DIFF
--- a/deploy/base/data-service-catalog-deployment.yaml
+++ b/deploy/base/data-service-catalog-deployment.yaml
@@ -56,6 +56,11 @@ spec:
                 secretKeyRef:
                   name: data-service-catalog
                   key: CORS_ORIGIN_PATTERNS
+            - name: OLD_BASE_URI
+              valueFrom:
+                secretKeyRef:
+                  name: commonurl
+                  key: DATASERVICE_CATALOG_BASE_URI
           image: data-service-catalog
           imagePullPolicy: Always
           ports:

--- a/src/main/kotlin/no/fdk/dataservicecatalog/ApplicationProperties.kt
+++ b/src/main/kotlin/no/fdk/dataservicecatalog/ApplicationProperties.kt
@@ -3,4 +3,4 @@ package no.fdk.dataservicecatalog
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties("application")
-data class ApplicationProperties(val baseUri: String, val organizationCatalogBaseUri: String)
+data class ApplicationProperties(val oldBaseUri: String, val organizationCatalogBaseUri: String)

--- a/src/main/kotlin/no/fdk/dataservicecatalog/handler/RDFHandler.kt
+++ b/src/main/kotlin/no/fdk/dataservicecatalog/handler/RDFHandler.kt
@@ -98,11 +98,11 @@ class RDFHandler(private val repository: DataServiceRepository, private val prop
     }
 
     private fun getCatalogUri(): String {
-        return buildUri(properties.baseUri, "/catalogs/")
+        return buildUri(properties.oldBaseUri, "/catalogs/")
     }
 
     private fun getDataServiceUri(catalogId: String): String {
-        return buildUri(properties.baseUri, "/catalogs/$catalogId/data-services/")
+        return buildUri(properties.oldBaseUri, "/data-services/")
     }
 
     private fun getOrganizationUri(): String {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -48,7 +48,7 @@ spring:
         type:
           json_format_mapper: no.fdk.dataservicecatalog.config.CustomJacksonJsonFormatMapper
 application:
-  base-uri: ${BASE_URI:http://localhost}
+  old-base-uri: ${OLD_BASE_URI}
   organization-catalog-base-uri: ${ORGANIZATION_CATALOG_BASE_URI:https://organization-catalog.staging.fellesdatakatalog.digdir.no}
   cors:
     originPatterns: "${CORS_ORIGIN_PATTERNS}"
@@ -76,6 +76,7 @@ spring:
       hibernate:
         format_sql: true
 application:
+  old-base-uri: http://localhost
   cors:
     originPatterns: "*"
 logging.level.no: DEBUG
@@ -103,5 +104,6 @@ spring:
       hibernate:
         format_sql: true
 application:
+  old-base-uri: http://localhost
   cors:
     originPatterns: "*"

--- a/src/test/kotlin/no/fdk/dataservicecatalog/unit/handler/RDFHandlerTest.kt
+++ b/src/test/kotlin/no/fdk/dataservicecatalog/unit/handler/RDFHandlerTest.kt
@@ -85,7 +85,7 @@ class RDFHandlerTest {
                     <http://www.w3.org/2002/07/owl#sameAs>
                             "https://data.brreg.no/enhetsregisteret/api/enheter/$catalogId" .
             
-            <$baseUri/catalogs/$catalogId/data-services/$dataServiceId>
+            <$baseUri/data-services/$dataServiceId>
                     rdf:type                  dcat:DataService;
                     dct:accessRights          <http://access-rights.com>;
                     dct:description           "description"@en;
@@ -123,7 +123,7 @@ class RDFHandlerTest {
             <$baseUri/catalogs/$catalogId>  rdf:type  dcat:Catalog;
                     dct:publisher  <$organizationCatalogBaseUri/organizations/$catalogId>;
                     dct:title      "Data service catalog ($catalogId)"@en;
-                    dcat:service   <$baseUri/catalogs/$catalogId/data-services/$dataServiceId> .
+                    dcat:service   <$baseUri/data-services/$dataServiceId> .
         """
 
         val expectedModel = ModelFactory.createDefaultModel()
@@ -139,7 +139,7 @@ class RDFHandlerTest {
         }
 
         properties.stub {
-            on { this.baseUri } doReturn baseUri
+            on { this.oldBaseUri } doReturn baseUri
             on { this.organizationCatalogBaseUri } doReturn organizationCatalogBaseUri
         }
 
@@ -202,7 +202,7 @@ class RDFHandlerTest {
                     <http://www.w3.org/2002/07/owl#sameAs>
                             "https://data.brreg.no/enhetsregisteret/api/enheter/$catalogId" .
             
-            <$baseUri/catalogs/$catalogId/data-services/$dataServiceId>
+            <$baseUri/data-services/$dataServiceId>
                     rdf:type                  dcat:DataService;
                     dct:accessRights          <http://access-rights.com>;
                     dct:description           "description"@en;
@@ -240,7 +240,7 @@ class RDFHandlerTest {
             <$baseUri/catalogs/$catalogId>  rdf:type  dcat:Catalog;
                     dct:publisher  <$organizationCatalogBaseUri/organizations/$catalogId>;
                     dct:title      "Data service catalog ($catalogId)"@en;
-                    dcat:service   <$baseUri/catalogs/$catalogId/data-services/$dataServiceId> .
+                    dcat:service   <$baseUri/data-services/$dataServiceId> .
         """
 
         val expectedModel = ModelFactory.createDefaultModel()
@@ -256,7 +256,7 @@ class RDFHandlerTest {
         }
 
         properties.stub {
-            on { this.baseUri } doReturn baseUri
+            on { this.oldBaseUri } doReturn baseUri
             on { this.organizationCatalogBaseUri } doReturn organizationCatalogBaseUri
         }
 
@@ -304,7 +304,7 @@ class RDFHandlerTest {
             PREFIX dcatap: <http://data.europa.eu/r5r/>
             PREFIX cv:    <http://data.europa.eu/m8g/>
 
-            <$baseUri/catalogs/$catalogId/data-services/$dataServiceId>
+            <$baseUri/data-services/$dataServiceId>
                     rdf:type                  dcat:DataService;
                     dct:accessRights          <http://access-rights.com>;
                     dct:description           "description"@en;
@@ -351,7 +351,7 @@ class RDFHandlerTest {
         }
 
         properties.stub {
-            on { this.baseUri } doReturn baseUri
+            on { this.oldBaseUri } doReturn baseUri
         }
 
         val dataService = handler.findDataServiceByCatalogIdAndDataServiceId(catalogId, dataServiceId, Lang.TURTLE)


### PR DESCRIPTION
Noen kataloger feiler etter ETL pga uventa verdier i databasen, første commit fikser det

For at høsteprosessen vår skal gjenkjenne kataloger og datatjenester som samme som har blitt høsta før må ressursene opprettes med BASE_URI fra det gamle apiet, fiks for det i andre commit