### PR TITLE
chore: enroll in central codeql setup

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,26 @@
+name: Code scanning (CodeQL)
+permissions:
+  contents: read
+  security-events: write
+
+on:
+  pull_request:
+    types: [ready_for_review, opened, reopened, synchronize]
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  codeql:
+    name: Run codeql scan
+    if: github.event.pull_request.draft == false
+    uses: Informasjonsforvaltning/workflows/.github/workflows/codeql.yaml@main
+    with:
+      language: java
+      java_version: '21'
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ git clone https://github.com/Informasjonsforvaltning/data-service-catalog.git
 cd data-service-catalog
 ```
 
-Start MongoDB and the application (either through your IDE using the dev profile, or via CLI):
+Start PostgreSQL and the application (either through your IDE using the dev profile, or via CLI):
 
 ```sh
 docker compose up -d


### PR DESCRIPTION
# Summary

- Add codeql.yaml calling the central reusable workflow (language: java, java_version 21)
- Disable repo-level CodeQL default setup (previously only scanned actions, not the JVM code)
- Fix README: app uses PostgreSQL, not MongoDB

Closes #44